### PR TITLE
Update actions to current majors (Node 20 deprecation)

### DIFF
--- a/.github/workflows/check-py-deb-pkg-versions-match.yml
+++ b/.github/workflows/check-py-deb-pkg-versions-match.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Check if ${{ inputs.python_version_file_path }} exists
         run: |

--- a/.github/workflows/get-formatted-version-string.yml
+++ b/.github/workflows/get-formatted-version-string.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Extract Version from Debian Changelog
         id: extract-version

--- a/.github/workflows/sbuild-pkg.yml
+++ b/.github/workflows/sbuild-pkg.yml
@@ -46,7 +46,7 @@ jobs:
         run: |
           echo "filename=${{ inputs.pkg }}_${{ inputs.version }}~gha${{ env.date }}+${{ matrix.arch }}_${{ matrix.distro }}" >> $GITHUB_ENV
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: sbuild deb pkg for ${{ matrix.distro }}+${{ matrix.arch }}
         uses: wlan-pi/sbuild-debian-package@main
         id: build-debian-package
@@ -54,7 +54,7 @@ jobs:
           distro: ${{ matrix.distro }}
           arch: ${{ matrix.arch }}
       - name: Archive artifacts and upload to GitHub
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ env.filename }}
           path: ${{ steps.build-debian-package.outputs.deb-package }}


### PR DESCRIPTION
Part of the org-wide actions audit. Bumps outdated actions to current majors to clear the Node 20 deprecation warnings:

- actions/checkout to v7
- actions/upload-artifact to v7
- actions/cache to v6 (where used)
- actions/setup-python to v6 (where used)
- github/codeql-action to v4 (where used)

Workflow YAML validated. No behavior changes intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
